### PR TITLE
When set use_portainer 'n', 'portainer_data' volumes still remains in docker-compose-prod.yml

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose-prod.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose-prod.yml
@@ -2,7 +2,10 @@ version: '3.3'
 
 volumes:
     postgres_data: {}
+{% if cookiecutter.use_portainer == 'y' %}
     portainer_data: {}
+{% endif %}
+
 
 services:
   backend:


### PR DESCRIPTION
When i set `use_portainer='n'` then `portainer_data: {}` volume remains in **docker-compose-prod.yml** file.
