### PR TITLE
Fix windows docker bug, convert CRLF to LF

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/Dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/Dockerfile
@@ -15,4 +15,8 @@ RUN pip install -r ./requirements.txt
 # upload scripts
 COPY ./scripts/entrypoint.sh ./scripts/start.sh ./scripts/gunicorn.sh /
 
+# Fix windows docker bug, convert CRLF to LF
+RUN sed -i 's/\r$//g' /start.sh && chmod +x /start.sh && sed -i 's/\r$//g' /entrypoint.sh && chmod +x /entrypoint.sh &&\
+    sed -i 's/\r$//g' /gunicorn.sh && chmod +x /gunicorn.sh
+
 WORKDIR /app


### PR DESCRIPTION
Hello.
Fixing error in backend container, in Windows docker enviroments:
`backend_1   | /usr/bin/env: ‘bash\r’: No such file or directory
`